### PR TITLE
Show warning message for unknown bits

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3061,6 +3061,11 @@ void static UpdateTip(CBlockIndex *pindexNew, const CChainParams& chainParams) {
             WarningBitsConditionChecker checker(bit);
             ThresholdState state = checker.GetStateFor(pindex, chainParams.GetConsensus(), warningcache[bit]);
             if (state == THRESHOLD_ACTIVE || state == THRESHOLD_LOCKED_IN) {
+                // Only warn about bits that aren't in your current BIP9 deployments vector
+                for (const auto& known_deployments : chainParams.GetConsensus().vDeployments) {
+                    if (known_deployments.bit == bit)
+                        continue;
+                }
                 const std::string strWarning = strprintf(_("Warning: unknown new rules activated (versionbit %i)"), bit);
                 if (bit == 28) // DUMMY TEST BIT
                     continue;


### PR DESCRIPTION
Some users were getting the following image showing up on the Qt Client. 
![image](https://user-images.githubusercontent.com/8285518/115434204-bb417780-a208-11eb-8d27-2197a65aee24.png)

- This code change should help make it so that only valid warning messages are displayed in the Qt Client if the code running the change doesn't have an associated bit assigned to a softfork. 
